### PR TITLE
New record once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v1.1.0
+
+- `useNewRecord` will now only return true for the first render
+
+## v1.0.0
+
+- Initial release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/focus-manager",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/focus-manager",
-      "version": "1.0.0",
+      "version": "1.1.0-alpha.1",
       "license": "ISC",
       "devDependencies": {
         "@swc/cli": "^0.1.57",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/react-manage-focus",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.1",
   "description": "React component to automatically move focus when elements are removed or added",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/use_new_record.test.jsx
+++ b/src/use_new_record.test.jsx
@@ -26,4 +26,11 @@ describe('useNewRecord', () => {
     const { result } = renderHook(() => useNewRecord(2), { wrapper: Wrapper });
     expect(result.current).toEqual(true);
   });
+
+  it('returns false for additional renders', () => {
+    const { rerender, result } = renderHook(() => useNewRecord(2), { wrapper: Wrapper });
+    expect(result.current).toEqual(true);
+    rerender();
+    expect(result.current).toEqual(false);
+  });
 });

--- a/src/use_new_record.ts
+++ b/src/use_new_record.ts
@@ -1,9 +1,14 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 
 import { Context } from './context.js';
 
 export function useNewRecord(id: Object | string | number | symbol) : boolean {
+  const usedRef = useRef<boolean>(false);
   const { initialIds } = useContext(Context);
 
-  return !!initialIds && !initialIds.has(id);
+  useEffect(() => {
+    usedRef.current = true;
+  }, []);
+
+  return !!initialIds && !initialIds.has(id) && !usedRef.current;
 }


### PR DESCRIPTION
Update `useNewRecord` to only be true for the first render.